### PR TITLE
Update docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
-#FROM library/node:6
-FROM ubuntu:xenial
+FROM node:19.4.0-bullseye-slim
 
 MAINTAINER "Daniel Garcia aka (cr0hn)" <cr0hn@cr0hn.com>
 
 ENV STAGE "DOCKER"
 
-RUN apt-get update && apt-get -y upgrade && \
-    apt-get install -y nodejs npm netcat
-
-# Fix node links
-RUN ln -s /usr/bin/nodejs /usr/bin/node
+RUN apt-get update && apt-get install -y netcat
 
 # Build app folders
 RUN mkdir /app
@@ -22,9 +17,6 @@ RUN npm install
 # Bundle code
 COPY . /app
 
-RUN chmod +x /app/start.sh
-
 EXPOSE 3000
 
-CMD [ "/app/start.sh" ]
-#CMD [ "npm", "start" ]
+CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
-version: '2'
+version: '3.9'
 services:
   vulnerable_node:
     restart: always
     build: .
+    depends_on:
+      - postgres_db
     ports:
       - "3000:3000"
-#    links:
-#      - postgres_db:postgres_db
     depends_on:
       - postgres_db
 

--- a/services/postgresql/Dockerfile
+++ b/services/postgresql/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/postgres
+FROM postgres:15.1-bullseye
 
 MAINTAINER "Daniel Garcia aka (cr0hn)" <cr0hn@cr0hn.com>
 

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# Wait until database is available
-while ! nc -z postgres_db 5432; do sleep 3; done
-
-npm start


### PR DESCRIPTION
- Using fixed version is safer as it won't break without warning
- Using official node image rather than taking a generic ubuntu and installing node on it
- Use docker ocmpose `depends_on` rather than a entrypoint with a wait in a while loop