### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       - postgres_db
     ports:
       - "3000:3000"
-    depends_on:
-      - postgres_db
 
   postgres_db:
     restart: always


### PR DESCRIPTION
The mapping key "depends_on" is defined twice, once at line 6 and then at line10 - which breaks the yaml syntax and causes build issues with docker-compose.